### PR TITLE
Add checkbox to display subset of crimes

### DIFF
--- a/CrimeNearExample/index.html
+++ b/CrimeNearExample/index.html
@@ -1,5 +1,5 @@
 <html>
-<head><title>Incidents - Last 180 Days - 1/2 Mile</title>
+<head><title>Incidents - Last 180 Days - .10 Mile</title>
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" />
 <script src="http://api.tiles.mapbox.com/mapbox.js/plugins/turf/v1.4.0/turf.min.js"></script>
@@ -23,14 +23,31 @@ var buffered
 var a;	
 var enveloped;
 
-	var map = L.map('map', {
-		center: [35.10418, -106.62987],
-		zoom:10
-	});
+var map = L.map('map', {
+	center: [35.10418, -106.62987],
+	zoom:10
+});
 
-	L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png').addTo(map);
+L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png').addTo(map);
 
+var onlyAutoAndBurglary = false; //initialize boolean for subset of crimes
+//create control for check box and add to map
+var command = L.control({position: 'bottomleft'});
+command.onAdd = function (map) {
+	var div = L.DomUtil.create('div', 'command');
+	div.innerHTML = '<form style="font-size:9pt; vertical-align:top; background-color:white; border-style:solid; border-width:1px; height:20px; width:135px; z-index:98;"><input id="command" type="checkbox"/>Only Auto & Burglary</form>';
+	return div;
+};
+command.addTo(map);
 
+document.getElementById("command").addEventListener("click", function(e) {
+	e.stopPropagation(); //prevent mouse click from propagating up to map, otherwise map will pan where it is clicked
+	if (this.checked) {
+		onlyAutoAndBurglary = true;
+	} else {
+		onlyAutoAndBurglary = false;
+	}
+});
 
 
 map.on("click",function(e){
@@ -39,16 +56,9 @@ a=L.marker(e.latlng);
 b=a.toGeoJSON();
 
 
-
-
-
-
-buffered = turf.buffer(b,.05,"miles");
+buffered = turf.buffer(b,.10,"miles");
 var result = turf.featurecollection(buffered.features.concat(b));
 g='{"rings":'+JSON.stringify(buffered.features[0].geometry.coordinates)+'}';
-
-
-
 
 
 var params="f=json&outSR=4326&outFields=*&geometryType=esriGeometryPolygon&spatialRel=esriSpatialRelIntersects&inSR=4326&geometry="+g;
@@ -63,24 +73,20 @@ http.onreadystatechange = function() {//Call a function when the state changes.
 		
 		var result= JSON.parse(http.responseText);
 		for(x=0;x<Object.keys(result.features).length;x++){
-			xy=result.features[x].geometry;
-		
-			navigator.vibrate(1000);
-			L.marker([result.features[x].geometry.y,result.features[x].geometry.x]).bindPopup("<h3>"+result.features[x].attributes.CVINC_TYPE+"</h3>").addTo(map);}
-	
-		
-		
-		
+			if (onlyAutoAndBurglary) { //only keep AUTO BURGLARY, AUTO THEFT, BURGLARY/BREAKING AND ENTERING
+				if (result.features[x].attributes.CVINC_TYPE == "AUTO BURGLARY" || result.features[x].attributes.CVINC_TYPE == "AUTO THEFT" || result.features[x].attributes.CVINC_TYPE == "BURGLARY/BREAKING AND ENTERING") {
+L.marker([result.features[x].geometry.y,result.features[x].geometry.x]).bindPopup("<h3>"+result.features[x].attributes.CVINC_TYPE+"</h3>").addTo(map);
+				}
+			} else { //show all crimes (default)
+L.marker([result.features[x].geometry.y,result.features[x].geometry.x]).bindPopup("<h3>"+result.features[x].attributes.CVINC_TYPE+"</h3>").addTo(map);
+			}
+		}
 
 }}
 http.send(params);
 
 
-
-
-
 });//end on
-
 
 
 </script>


### PR DESCRIPTION
- Add checkbox and corresponding functionality to display subset of crimes on the map.
- Prevent mouse click propagation up to map when clicking checkbox.
- Expand buffer from .05 to .10 miles.
